### PR TITLE
Build RLSD in a VM with all build dependencies automatically installed using Vagrant 

### DIFF
--- a/vagrant-build-environment/README.md
+++ b/vagrant-build-environment/README.md
@@ -4,17 +4,37 @@ Follow these instruction to create a virtualized build environment and build RLS
 
 1\. Install VirtualBox and [Vagrant](https://www.vagrantup.com/downloads.html).
 
-2\. Run the following commands in the terminal from `rlsd/vagrant-build-environment` (the directory in which you found this README file).
+2\. Run the following commands in the terminal from `rlsd/vagrant-build-environment` (the directory in which you found this README file):
 
 ```
 vagrant box add ubuntu/trusty32
 vagrant box add ubuntu/trusty64
-vagrant up
 ```
 
-This will start the automatic process of provisioning a 32-bit and a 64-bit Ubuntu 14.04 virtual machine to build RLSD in and building RLSD within them.
+Then depending on whether you want to produce a 32-bit or a 64-bit build of RLSD run either
 
-3\. Wait. It will take a while to build the ISO disc images for both the i686 and the x86_64 version. By the end of the process .iso files will appear in `rlsd/vagrant-build-environment`.
+```
+# i686
+vagrant up v32
+```
+
+or
+
+```
+# x86_64
+vagrant up v64
+```
+
+This will start the automatic process of provisioning an Ubuntu 14.04 virtual machine (VM) to build RLSD in and building RLSD within it.
+
+To build both (using twice the RAM) run
+
+```
+# i686 _and_ x86_64
+vagrant up v32 v64
+```
+
+3\. Wait. It will take a while to build the ISO disc images. By the end of the process .iso files will appear in `rlsd/releases`.
 
 4\. (optional) To work interactively in a build environment VM type
 
@@ -28,14 +48,10 @@ or
 vagrant ssh v64
 ```
 
-5\. Shut down the VMs with
+5\. Destroy the build VM with
 
 ```
-vagrant down
+vagrant destroy
 ```
 
-6\. Next time run
-
-```vagrant reload --provision```
-
-to **delete** the content of the VMs and repeat the build process.
+Note that this will **delete all the data stored on the VM(s)**. This is done to ensure a clean build each time that is not affected by the artifacts of a previous build.

--- a/vagrant-build-environment/Vagrantfile
+++ b/vagrant-build-environment/Vagrantfile
@@ -8,11 +8,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, path: "bootstrap.sh"
   config.vm.synced_folder "../releases/", "/releases"
 
-  config.vm.define "v32" do |v32|
+  config.vm.define "v32", autostart: false do |v32|
     v32.vm.box = "ubuntu/trusty32"
   end
 
-  config.vm.define "v64" do |v64|
+  config.vm.define "v64", autostart: false do |v64|
     v64.vm.box = "ubuntu/trusty64"
   end
 end

--- a/vagrant-build-environment/bootstrap.sh
+++ b/vagrant-build-environment/bootstrap.sh
@@ -2,14 +2,14 @@
 apt-get update
 apt-get -y install git build-essential libarchive-dev libcurl4-gnutls-dev zlib1g-dev libsqlite3-dev squashfs-tools xorriso mtools
 
-# packdude
+# get, build and install packdude
 git clone https://github.com/dimkr/packdude.git
 cd packdude
 make
 make install
 cd ..
 
-# rlsd itself
+# get and build RLSD itself
 git clone https://github.com/dimkr/rlsd.git
 cd rlsd
 make


### PR DESCRIPTION
This makes it easier for anyone to build RLSD from the Git repository on different systems (at least on Linux) as well as to keep track of the complete list of build dependencies you need installed in Ubuntu to build RLSD. See the file `README.md` for the details of the build process.

Edit: title.
